### PR TITLE
Integrate with babel-plugin-transform-define

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,9 @@
 {
-  "plugins": ["transform-runtime", "transform-decorators-legacy"],
+  "plugins": [
+    "transform-runtime",
+    "transform-decorators-legacy",
+    ["transform-define", "./config/defines"],
+  ],
   "presets": ["es2015", "stage-1", "react"],
   "env": {
     // only enable it when process.env.NODE_ENV is 'development' or undefined

--- a/config/defines.js
+++ b/config/defines.js
@@ -1,0 +1,4 @@
+import * as config from '.';
+
+// Replacements for https://github.com/mjackson/babel-plugin-transform-define
+export default config.flatten(config.current, '__CONFIG__.', '.');

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -21,8 +21,6 @@ export default {
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),
     new webpack.DefinePlugin({
-      // Expand config values into `__CONFIG__.path.to.value`
-      '__CONFIG__': config.defines(config.current),
       // For dependencies like React and Redux that expect this to exist.
       'process.env.NODE_ENV': JSON.stringify(config.current.variant),
     }),

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -19,8 +19,6 @@ export default {
   plugins: [
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.DefinePlugin({
-      // Expand config values into `__CONFIG__.path.to.value`
-      '__CONFIG__': config.defines(config.current),
       // For dependencies like React and Redux that expect this to exist.
       'process.env.NODE_ENV': JSON.stringify(config.current.variant),
     }),

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "devserver": "scripts/devserver.js",
     "deploy:push": "scripts/deploy:push.sh",
     "deploy": "scripts/deploy.sh",
+    "postinstall": "scripts/postinstall.sh",
     "start": "scripts/devserver.js",
     "test:unit": "scripts/test:unit.sh"
   },
@@ -32,6 +33,7 @@
     "babel-plugin-react-transform": "^2.0.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-runtime": "^6.4.3",
+    "babel-plugin-transform-define": "nevir/babel-plugin-transform-define#required-replacements",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.1.1",

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+# Hack until the PR is merged:
+# https://github.com/mjackson/babel-plugin-transform-define/pull/3
+# Due to npm bug:
+# https://github.com/npm/npm/issues/3055
+pushd node_modules/babel-plugin-transform-define
+npm run build
+popd


### PR DESCRIPTION
Replace Webpack DefinePlugin with a babel equivalent. Because our unit tests don't run against the Webpack bundle, the DefinePlugin variables were throwing undefined errors.

Basically a carbon copy of: https://github.com/convoyinc/carrier-mobile/commit/81fd914d43dce6059e7cfcca89c2a1614dceb8b4
